### PR TITLE
Real closures

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ package test1 (
         if n < 2 (
             1
          ) else (
-            n * fac(n - 1)
+            n * recurse(n - 1)
          )
     )
 
@@ -74,7 +74,7 @@ paquet test1 (
         si n < 2 (
             retourne 1
         ) sinon (
-            retourne n * factorielle(n - 1)
+            retourne n * recurrence(n - 1)
         )
     )
 

--- a/src/main/antlr4/org/babblelang/parser/Babble.g4
+++ b/src/main/antlr4/org/babblelang/parser/Babble.g4
@@ -91,6 +91,6 @@ OR: 'or' | 'ou';
 NULL: 'null' | 'vide';
 NOT: 'not' | 'non';
 BOOLEAN: 'true' | 'false' | 'vrai' | 'faux';
-RECURSE: 'recurse' | 'recursionne';
+RECURSE: 'recurse' | 'recurrence';
 ID: [_a-zA-Z] [_a-zA-Z0-9]*;
 WS: [ \t\r\n]+ -> skip;

--- a/src/main/antlr4/org/babblelang/parser/Babble.g4
+++ b/src/main/antlr4/org/babblelang/parser/Babble.g4
@@ -36,6 +36,7 @@ expression: '(' expression ')'                               # parenthesis
           | ID '=' expression                                # assign
           | NULL                                             # null
           | BOOLEAN                                          # boolean
+          | RECURSE                                          # recurse
           | ID                                               # id
           | INT                                              # integer
           | FLOAT                                            # double
@@ -90,5 +91,6 @@ OR: 'or' | 'ou';
 NULL: 'null' | 'vide';
 NOT: 'not' | 'non';
 BOOLEAN: 'true' | 'false' | 'vrai' | 'faux';
+RECURSE: 'recurse' | 'recursionne';
 ID: [_a-zA-Z] [_a-zA-Z0-9]*;
 WS: [ \t\r\n]+ -> skip;

--- a/src/main/java/org/babblelang/engine/impl/Function.java
+++ b/src/main/java/org/babblelang/engine/impl/Function.java
@@ -16,8 +16,8 @@ public class Function extends BabbleBaseVisitor<Object> implements Callable {
         // Compute closure
         ClosureExtractor closureExtractor = new ClosureExtractor();
         closureExtractor.visit(definition);
-        this.closure = scope.closure(closureExtractor.getClosureKeys());
-        this.closure.define("$recurse", this);
+        closure = scope.closure(closureExtractor.getClosureKeys());
+        closure.define("$recurse", this);
     }
 
     public Scope bindParameters(Interpreter interpreter, Scope parent, Parameters parameters) {

--- a/src/main/java/org/babblelang/engine/impl/Function.java
+++ b/src/main/java/org/babblelang/engine/impl/Function.java
@@ -54,6 +54,7 @@ public class Function extends BabbleBaseVisitor<Object> implements Callable {
     private static class ClosureExtractor extends BabbleBaseVisitor<Void> {
         private Scope functionScope;
         private Set<String> closureKeys;
+        private boolean root = true;
 
         public ClosureExtractor() {
             functionScope = new Scope();
@@ -78,9 +79,12 @@ public class Function extends BabbleBaseVisitor<Object> implements Callable {
 
         @Override
         public Void visitFunctionLiteral(BabbleParser.FunctionLiteralContext ctx) {
-            functionScope = functionScope.enter(null);
-            super.visitFunctionLiteral(ctx);
-            functionScope = functionScope.leave();
+            if (root) {
+                // No need to visit inner functions
+                // Their closure will be computed in time
+                root = false;
+                super.visitFunctionLiteral(ctx);
+            }
             return null;
         }
 

--- a/src/main/java/org/babblelang/engine/impl/Function.java
+++ b/src/main/java/org/babblelang/engine/impl/Function.java
@@ -16,7 +16,7 @@ public class Function extends BabbleBaseVisitor<Object> implements Callable {
         // Compute closure
         ClosureExtractor closureExtractor = new ClosureExtractor();
         closureExtractor.visit(definition);
-        this.closure = scope.closure(closureExtractor.closureKeys);
+        this.closure = scope.closure(closureExtractor.getClosureKeys());
         this.closure.define("$recurse", this);
     }
 
@@ -109,6 +109,10 @@ public class Function extends BabbleBaseVisitor<Object> implements Callable {
             }
 
             return super.visitId(ctx);
+        }
+
+        private Set<String> getClosureKeys() {
+            return closureKeys;
         }
     }
 }

--- a/src/main/java/org/babblelang/engine/impl/Function.java
+++ b/src/main/java/org/babblelang/engine/impl/Function.java
@@ -3,16 +3,23 @@ package org.babblelang.engine.impl;
 import org.babblelang.parser.BabbleBaseVisitor;
 import org.babblelang.parser.BabbleParser;
 
+import java.util.HashSet;
+import java.util.Set;
+
 public class Function extends BabbleBaseVisitor<Object> implements Callable {
     private final BabbleParser.FunctionLiteralContext definition;
     private final Scope closure;
 
     public Function(BabbleParser.FunctionLiteralContext definition, Scope scope) {
         this.definition = definition;
-        this.closure = scope;
+
+        // Compute closure
+        ClosureExtractor closureExtractor = new ClosureExtractor();
+        closureExtractor.visit(definition);
+        this.closure = scope.closure(closureExtractor.closureKeys);
+        this.closure.define("$recurse", this);
     }
 
-    @Override
     public Scope bindParameters(Interpreter interpreter, Scope parent, Parameters parameters) {
         Scope scope = closure.enter(null);
 
@@ -34,7 +41,6 @@ public class Function extends BabbleBaseVisitor<Object> implements Callable {
         return scope;
     }
 
-    @Override
     public Object call(Interpreter interpreter, Scope scope) {
         return interpreter.visit(definition.block());
     }
@@ -42,6 +48,67 @@ public class Function extends BabbleBaseVisitor<Object> implements Callable {
     private void checkType(BabbleParser.ParameterDeclarationContext parameter, Object value) {
         if (value instanceof Scope) {
             throw new IllegalArgumentException("Parameter type mismatch : " + parameter.ID().getText() + " is expected to be of type " + parameter.type().getText() + ", got " + value.getClass().getCanonicalName());
+        }
+    }
+
+    private static class ClosureExtractor extends BabbleBaseVisitor<Void> {
+        private Scope functionScope;
+        private Set<String> closureKeys;
+
+        public ClosureExtractor() {
+            functionScope = new Scope();
+            closureKeys = new HashSet<String>();
+        }
+
+        @Override
+        public Void visitPackageStatement(BabbleParser.PackageStatementContext ctx) {
+            functionScope = functionScope.enter(ctx.ID().getText());
+            super.visitPackageStatement(ctx);
+            functionScope = functionScope.leave();
+            return null;
+        }
+
+        @Override
+        public Void visitBlock(BabbleParser.BlockContext ctx) {
+            functionScope = functionScope.enter(null);
+            super.visitBlock(ctx);
+            functionScope = functionScope.leave();
+            return null;
+        }
+
+        @Override
+        public Void visitFunctionLiteral(BabbleParser.FunctionLiteralContext ctx) {
+            functionScope = functionScope.enter(null);
+            super.visitFunctionLiteral(ctx);
+            functionScope = functionScope.leave();
+            return null;
+        }
+
+        @Override
+        public Void visitParameterDeclaration(BabbleParser.ParameterDeclarationContext ctx) {
+            functionScope.define(ctx.ID().getText(), true);
+            return super.visitParameterDeclaration(ctx);
+        }
+
+        @Override
+        public Void visitDefStatement(BabbleParser.DefStatementContext ctx) {
+            super.visitDefStatement(ctx);
+            functionScope.define(ctx.ID().getText(), true);
+            return null;
+        }
+
+        @Override
+        public Void visitId(BabbleParser.IdContext ctx) {
+            String name = ctx.ID().getText();
+
+            if (functionScope.isDeclared(name)) {
+                // if the ID has been defined within the function
+                // then we don't need it in the closure
+            } else {
+                closureKeys.add(name);
+            }
+
+            return super.visitId(ctx);
         }
     }
 }

--- a/src/main/java/org/babblelang/engine/impl/Interpreter.java
+++ b/src/main/java/org/babblelang/engine/impl/Interpreter.java
@@ -42,6 +42,7 @@ public class Interpreter extends BabbleBaseVisitor<Object> {
             value = visit(ctx.expression());
         }
         scope.define(id, value);
+
         return value;
     }
 
@@ -251,5 +252,10 @@ public class Interpreter extends BabbleBaseVisitor<Object> {
             params.put(name, value);
         }
         return params;
+    }
+
+    @Override
+    public Object visitRecurse(BabbleParser.RecurseContext ctx) {
+        return scope.get("$recurse");
     }
 }

--- a/src/main/java/org/babblelang/engine/impl/Scope.java
+++ b/src/main/java/org/babblelang/engine/impl/Scope.java
@@ -2,6 +2,7 @@ package org.babblelang.engine.impl;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 public class Scope {
     private final Scope parent;
@@ -30,6 +31,16 @@ public class Scope {
         return newScope;
     }
 
+    public Scope closure(Set<String> closureKeys) {
+        Scope result = parent != null ? parent.enter(null) : new Scope();
+        for (String key : closureKeys) {
+            if (locals.containsKey(key)) {
+                result.define(key, locals.get(key));
+            }
+        }
+        return result;
+    }
+
     public Scope leave() {
         if (parent == null) {
             throw new IllegalStateException("Too many calls to leave()");
@@ -49,6 +60,33 @@ public class Scope {
         for (Map.Entry<String, Object> entry : values.entrySet()) {
             define(entry.getKey(), entry.getValue());
         }
+    }
+
+    public boolean isLocal(String key) {
+        return locals.containsKey(key);
+    }
+
+    public boolean isDeclared(String key) {
+        return isDeclaredWithin(null, key);
+    }
+
+    /**
+     * Returns whether the given key has been defined in this scope
+     * or up to the given root.
+     */
+    public boolean isDeclaredWithin(Scope root, String key) {
+        Scope current = this;
+        while (current != null) {
+            if (current.locals.containsKey(key)) {
+                return true;
+            } else {
+                if (current == root) {
+                    break;
+                }
+                current = current.parent;
+            }
+        }
+        return false;
     }
 
     public Object assign(String key, Object value) {
@@ -75,4 +113,5 @@ public class Scope {
         }
         throw new IllegalArgumentException("No such key : " + key);
     }
+
 }

--- a/src/main/java/org/babblelang/engine/impl/Scope.java
+++ b/src/main/java/org/babblelang/engine/impl/Scope.java
@@ -32,7 +32,12 @@ public class Scope {
     }
 
     public Scope closure(Set<String> closureKeys) {
-        Scope result = parent != null ? parent.enter(null) : new Scope();
+        // No closure for root scope
+        if (parent == null) {
+            return enter(null);
+        }
+
+        Scope result = parent.enter(null);
         for (String key : closureKeys) {
             if (locals.containsKey(key)) {
                 result.define(key, locals.get(key));

--- a/src/main/java/org/babblelang/engine/impl/natives/PrintFunction.java
+++ b/src/main/java/org/babblelang/engine/impl/natives/PrintFunction.java
@@ -13,14 +13,12 @@ public class PrintFunction implements Callable {
         this.newLine = newLine;
     }
 
-    @Override
     public Scope bindParameters(Interpreter interpreter, Scope parent, Parameters parameters) {
         Scope scope = parent.enter(null);
         scope.define("...", parameters);
         return scope;
     }
 
-    @Override
     public Object call(Interpreter interpreter, Scope scope) {
         Parameters params = (Parameters) scope.get("...");
 

--- a/src/test/babble/Test1-fr.ba
+++ b/src/test/babble/Test1-fr.ba
@@ -13,7 +13,7 @@ paquet test1 (
         si n < 2 (
             retourne 1
         ) sinon (
-            retourne n * factorielle(n - 1)
+            retourne n * recursionne(n - 1)
         )
     )
 

--- a/src/test/babble/Test1-fr.ba
+++ b/src/test/babble/Test1-fr.ba
@@ -13,12 +13,12 @@ paquet test1 (
         si n < 2 (
             retourne 1
         ) sinon (
-            retourne n * recursionne(n - 1)
+            retourne n * recurrence(n - 1)
         )
     )
 
     soit factorielle2 = (n:int):int -> (
-        soit resultat = 1;
+        soit resultat = 1
         tant que n > 1 (
             resultat = resultat * n ; n = n - 1
         )

--- a/src/test/babble/Test1.ba
+++ b/src/test/babble/Test1.ba
@@ -13,7 +13,7 @@ package test1 (
         if n < 2 (
             1
          ) else (
-            n * fac(n - 1)
+            n * recurse(n - 1)
          )
     )
 

--- a/src/test/java/org/babblelang/tests/BabbleFunctionsTestCase.java
+++ b/src/test/java/org/babblelang/tests/BabbleFunctionsTestCase.java
@@ -33,6 +33,6 @@ public class BabbleFunctionsTestCase extends BabbleTestBase {
     }
 
     public void testRecursion() throws Exception {
-        assertEquals(120, interpret("def fac = (n:int):int -> ( if(n<=1) ( 1 ) else ( n * fac(n-1) ) ) ; fac(5)"));
+        assertEquals(120, interpret("def fac = (n:int):int -> ( if(n<=1) ( 1 ) else ( n * recurse(n-1) ) ) ; fac(5)"));
     }
 }

--- a/src/test/java/org/babblelang/tests/BabbleFunctionsTestCase.java
+++ b/src/test/java/org/babblelang/tests/BabbleFunctionsTestCase.java
@@ -32,6 +32,10 @@ public class BabbleFunctionsTestCase extends BabbleTestBase {
         assertEquals(2005, interpret("def a = 99 ; def c = 1000; def adder = (a:int):(b:int):int -> ( (b:int):int -> ( a + b + c) ) ; def plus1 = adder(1) ; plus1(1) + plus1(2)"));
     }
 
+    public void testClosureMemory() throws Exception {
+        assertEquals(2005, interpret("def a = 99 ; def c = 1000; def adder = (a:int,d:int):(b:int):int -> ( (b:int):int -> ( a + b + c ) ) ; def plus1 = adder(1,0) ; plus1(1) + plus1(2)"));
+    }
+
     public void testRecursion() throws Exception {
         assertEquals(120, interpret("def fac = (n:int):int -> ( if(n<=1) ( 1 ) else ( n * recurse(n-1) ) ) ; fac(5)"));
     }


### PR DESCRIPTION
Closure are currently implemented as "poor man's closures" on the master branch : the full scope of a function declaration is kept for function execution, thus potentially retaining unneeded data in memory. This branch solves this problem by computing the proper closure for a function. This is done by finding the nearest static scope, looking up used names in the function definition, and keeping only the ones that are required in the closure.
