### PR TITLE
Modernize toolchain: Java 21, JUnit 5, refreshed CI actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,18 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: maven
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +63,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -69,4 +76,4 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
+    - uses: actions/checkout@v4
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
       with:
-        java-version: '11'
+        java-version: '21'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-Babble is a toy programming language running on the JVM, built as a learning project for parsing/interpreting. It uses ANTLR4 for parsing and currently runs in interpreted mode directly on the ANTLR parse tree (no bytecode compilation yet). Java 8 source level, JUnit 4 for tests.
+Babble is a toy programming language running on the JVM, built as a learning project for parsing/interpreting. It uses ANTLR4 for parsing and currently runs in interpreted mode directly on the ANTLR parse tree (no bytecode compilation yet). Java 21 source level, JUnit 5 (Jupiter) for tests.
 
 ## Commands
 
-- Build & test: `mvn package` (CI runs `mvn -B package` on JDK 11)
+- Build & test: `mvn package` (CI runs `mvn -B package` on JDK 21)
 - Run tests only: `mvn test`
 - Run a single test class: `mvn test -Dtest=BabbleFunctionsTestCase`
 - Run a single test method: `mvn test -Dtest=BabbleFunctionsTestCase#methodName`
@@ -19,10 +19,10 @@ The host (immutable Fedora) has no Java or Maven installed. Run Maven in a conta
 
 ```
 podman run --rm -v /var/home/nlehuen/babble:/work:z -v ~/.m2:/root/.m2:z -w /work \
-    docker.io/library/maven:3.9-eclipse-temurin-11 mvn -B clean test
+    docker.io/library/maven:3.9-eclipse-temurin-21 mvn -B clean test
 ```
 
-The image matches CI's JDK 11; mounting `~/.m2` caches dependencies between runs, and the `:z` volume flags are required for SELinux.
+The image matches CI's JDK 21; mounting `~/.m2` caches dependencies between runs, and the `:z` volume flags are required for SELinux.
 
 The ANTLR lexer/parser/visitor classes (`org.babblelang.parser.*`) are **generated** by the `antlr4-maven-plugin` into `target/generated-sources/antlr4` from `src/main/antlr4/org/babblelang/parser/Babble.g4`. Never edit generated parser code; change the grammar and rebuild. Grammar changes require `mvn generate-sources` (or any build) before the new contexts are visible to Java code.
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,18 +8,21 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>21</maven.compiler.release>
+        <antlr.version>4.13.2</antlr.version>
+        <junit.version>6.1.2</junit.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
-            <version>4.13.2</version>
+            <version>${antlr.version}</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -31,14 +34,16 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.15.0</version>
-                <configuration>
-                    <release>8</release>
-                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.6</version>
             </plugin>
             <plugin>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>
-                <version>4.13.2</version>
+                <version>${antlr.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/test/java/org/babblelang/tests/AssertFunction.java
+++ b/src/test/java/org/babblelang/tests/AssertFunction.java
@@ -3,16 +3,18 @@ package org.babblelang.tests;
 import org.babblelang.engine.impl.Interpreter;
 import org.babblelang.engine.impl.Scope;
 import org.babblelang.parser.BabbleParser;
-import org.junit.Assert;
+import org.opentest4j.AssertionFailedError;
 
 public class AssertFunction extends org.babblelang.engine.impl.natives.AssertFunction {
     public Boolean call(Interpreter interpreter, BabbleParser.CallContext callSite, Scope scope) {
         String message = (String) scope.get("message").get();
         boolean test = (Boolean) scope.get("test").get();
-        if (message == null) {
-            Assert.assertTrue("Assertion failed at line " + callSite.getStart().getLine() + " : " + callSite.callParameters().callParameter(0).expression().getText(), test);
-        } else {
-            Assert.assertTrue(message, test);
+        if (!test) {
+            // Thrown directly rather than via Assertions.assertTrue, which would append
+            // its own "==> expected: <true> but was: <false>" to the reported message.
+            throw new AssertionFailedError(message != null
+                    ? message
+                    : "Assertion failed at line " + callSite.getStart().getLine() + " : " + callSite.callParameters().callParameter(0).expression().getText());
         }
         return true;
     }

--- a/src/test/java/org/babblelang/tests/BabbleControlTestCase.java
+++ b/src/test/java/org/babblelang/tests/BabbleControlTestCase.java
@@ -1,39 +1,39 @@
 package org.babblelang.tests;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class BabbleControlTestCase extends BabbleTestBase {
     @Test
     public void testBooleanIf() throws Exception {
-        Assert.assertEquals(1, interpret("if 1 < 2 then ( 1 ) else ( 2 ) "));
-        Assert.assertEquals(2, interpret("if 1 > 2 then (1) else (2) "));
-        Assert.assertEquals(null, interpret("if 1 > 2 then ( 1 ; 2 )"));
+        Assertions.assertEquals(1, interpret("if 1 < 2 then ( 1 ) else ( 2 ) "));
+        Assertions.assertEquals(2, interpret("if 1 > 2 then (1) else (2) "));
+        Assertions.assertEquals(null, interpret("if 1 > 2 then ( 1 ; 2 )"));
     }
 
     @Test
     public void testNumberIf() throws Exception {
-        Assert.assertEquals(1, interpret("if 1 then ( 1 ) else (2) "));
-        Assert.assertEquals(2, interpret("if 0 then ( 1 ) else (2) "));
-        Assert.assertEquals(1, interpret("if 1.5 + 1.5 then ( 1 ) else (2) "));
-        Assert.assertEquals(2, interpret("if 1.5 - 1.5 then ( 1 ) else (2) "));
+        Assertions.assertEquals(1, interpret("if 1 then ( 1 ) else (2) "));
+        Assertions.assertEquals(2, interpret("if 0 then ( 1 ) else (2) "));
+        Assertions.assertEquals(1, interpret("if 1.5 + 1.5 then ( 1 ) else (2) "));
+        Assertions.assertEquals(2, interpret("if 1.5 - 1.5 then ( 1 ) else (2) "));
     }
 
     @Test
     public void testObjectIf() throws Exception {
-        Assert.assertEquals(1, interpret("if \"coucou\" then ( 1 ) else (2) "));
-        Assert.assertEquals(2, interpret("if null then ( 1 ) else (2) "));
+        Assertions.assertEquals(1, interpret("if \"coucou\" then ( 1 ) else (2) "));
+        Assertions.assertEquals(2, interpret("if null then ( 1 ) else (2) "));
     }
 
     @Test
     public void testIfWithoutElse() throws Exception {
-        Assert.assertEquals(null, interpret("if 1 > 2 then ( 3 + 3 + 3 )"));
-        Assert.assertEquals(9, interpret("if 1 < 2 then ( 3 + 3 + 3 )"));
-        Assert.assertEquals(3, interpret("if 1 < 2 then ( 1 ; 2 ; 3 )"));
+        Assertions.assertEquals(null, interpret("if 1 > 2 then ( 3 + 3 + 3 )"));
+        Assertions.assertEquals(9, interpret("if 1 < 2 then ( 3 + 3 + 3 )"));
+        Assertions.assertEquals(3, interpret("if 1 < 2 then ( 1 ; 2 ; 3 )"));
     }
 
     @Test
     public void testWhile() throws Exception {
-        Assert.assertEquals(10, interpret("def i = 0 ; while i<10 then ( i = i + 1 ) ; i"));
+        Assertions.assertEquals(10, interpret("def i = 0 ; while i<10 then ( i = i + 1 ) ; i"));
     }
 }

--- a/src/test/java/org/babblelang/tests/BabbleEnvironmentTestCase.java
+++ b/src/test/java/org/babblelang/tests/BabbleEnvironmentTestCase.java
@@ -1,25 +1,25 @@
 package org.babblelang.tests;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class BabbleEnvironmentTestCase extends BabbleTestBase {
     @Test
     public void testAssert() throws Exception {
-        Assert.assertEquals(true, interpret("assert(1<2)"));
+        Assertions.assertEquals(true, interpret("assert(1<2)"));
 
         try {
-            Assert.assertEquals(false, interpret("assert(1>2)"));
-            Assert.fail("Should fail assertion");
+            Assertions.assertEquals(false, interpret("assert(1>2)"));
+            Assertions.fail("Should fail assertion");
         } catch (AssertionError e) {
-            Assert.assertEquals("Assertion failed at line 1 : 1>2", e.getMessage());
+            Assertions.assertEquals("Assertion failed at line 1 : 1>2", e.getMessage());
         }
 
         try {
-            Assert.assertEquals(false, interpret("assert(1>2, \"Something is wrong\")"));
-            Assert.fail("Should fail assertion");
+            Assertions.assertEquals(false, interpret("assert(1>2, \"Something is wrong\")"));
+            Assertions.fail("Should fail assertion");
         } catch (AssertionError e) {
-            Assert.assertEquals("Something is wrong", e.getMessage());
+            Assertions.assertEquals("Something is wrong", e.getMessage());
         }
     }
 }

--- a/src/test/java/org/babblelang/tests/BabbleExpressionsTestCase.java
+++ b/src/test/java/org/babblelang/tests/BabbleExpressionsTestCase.java
@@ -1,144 +1,144 @@
 package org.babblelang.tests;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.script.ScriptException;
 
 public class BabbleExpressionsTestCase extends BabbleTestBase {
     @Test
     public void testIntegerLiteral() throws Exception {
-        Assert.assertEquals(1, interpret("1"));
+        Assertions.assertEquals(1, interpret("1"));
     }
 
     @Test
     public void testNumberLiteral() throws Exception {
-        Assert.assertEquals(1.5, interpret("1.5"));
+        Assertions.assertEquals(1.5, interpret("1.5"));
     }
 
     @Test
     public void testMul() throws Exception {
-        Assert.assertEquals(144, interpret("12 * 12"));
-        Assert.assertEquals(6.0, interpret("12 * 0.5"));
-        Assert.assertEquals(0.25, interpret("0.5 * 0.5"));
+        Assertions.assertEquals(144, interpret("12 * 12"));
+        Assertions.assertEquals(6.0, interpret("12 * 0.5"));
+        Assertions.assertEquals(0.25, interpret("0.5 * 0.5"));
     }
 
     @Test
     public void testDiv() throws Exception {
-        Assert.assertEquals(12.0, interpret("144 / 12"));
-        Assert.assertEquals(144.0, interpret("12 / (1 / 12)"));
+        Assertions.assertEquals(12.0, interpret("144 / 12"));
+        Assertions.assertEquals(144.0, interpret("12 / (1 / 12)"));
     }
 
     @Test
     public void testAdd() throws Exception {
-        Assert.assertEquals(23, interpret("  12 + 11 "));
-        Assert.assertEquals(23.5, interpret("  12 + 11.5 "));
-        Assert.assertEquals(24.0, interpret("  12.5 + 11.5 "));
+        Assertions.assertEquals(23, interpret("  12 + 11 "));
+        Assertions.assertEquals(23.5, interpret("  12 + 11.5 "));
+        Assertions.assertEquals(24.0, interpret("  12.5 + 11.5 "));
     }
 
     @Test
     public void testWrongTypeAdd() {
         try {
-            Assert.assertEquals(null, interpret("  12 + \"to\" + \"to\" "));
-            Assert.fail("Should report type error");
+            Assertions.assertEquals(null, interpret("  12 + \"to\" + \"to\" "));
+            Assertions.fail("Should report type error");
         } catch (ScriptException e) {
-            Assert.assertEquals("org.babblelang.engine.BabbleException: Not a number : \"to\" in <input> at line number 1", e.getMessage());
+            Assertions.assertEquals("org.babblelang.engine.BabbleException: Not a number : \"to\" in <input> at line number 1", e.getMessage());
         }
         try {
-            Assert.assertEquals(null, interpret("  null + 12 "));
-            Assert.fail("Should report type error");
+            Assertions.assertEquals(null, interpret("  null + 12 "));
+            Assertions.fail("Should report type error");
         } catch (ScriptException e) {
-            Assert.assertEquals("org.babblelang.engine.BabbleException: Not a number : null in <input> at line number 1", e.getMessage());
+            Assertions.assertEquals("org.babblelang.engine.BabbleException: Not a number : null in <input> at line number 1", e.getMessage());
         }
     }
 
 
     @Test
     public void testMinus() throws Exception {
-        Assert.assertEquals(1, interpret("12 - 11"));
-        Assert.assertEquals(1.5, interpret("12.5 - 11"));
-        Assert.assertEquals(0.5, interpret("12 - 11.5"));
+        Assertions.assertEquals(1, interpret("12 - 11"));
+        Assertions.assertEquals(1.5, interpret("12.5 - 11"));
+        Assertions.assertEquals(0.5, interpret("12 - 11.5"));
     }
 
     @Test
     public void testPrecedence() throws Exception {
-        Assert.assertEquals(155, interpret("  12 * 12 + 11 "));
-        Assert.assertEquals(155, interpret("  11 + 12 * 12 "));
+        Assertions.assertEquals(155, interpret("  12 * 12 + 11 "));
+        Assertions.assertEquals(155, interpret("  11 + 12 * 12 "));
     }
 
     @Test
     public void testParen() throws Exception {
-        Assert.assertEquals(155, interpret("  (12 * 12) + 11 "));
-        Assert.assertEquals(276, interpret("  12 * (12 + 11) "));
+        Assertions.assertEquals(155, interpret("  (12 * 12) + 11 "));
+        Assertions.assertEquals(276, interpret("  12 * (12 + 11) "));
     }
 
     @Test
     public void testDef() throws Exception {
-        Assert.assertEquals(315, interpret("  def a = (12 * 12) + 11 ; a + a + 5"));
+        Assertions.assertEquals(315, interpret("  def a = (12 * 12) + 11 ; a + a + 5"));
     }
 
     @Test
     public void testStringLiteral() throws Exception {
-        Assert.assertEquals("ab6cd", interpret("  \"ab\" + 6 + \"cd\" "));
-        Assert.assertEquals("ab2", interpret("  \"ab\" + 2"));
-        Assert.assertEquals("ab\"2", interpret("  \"ab\\\"\" + 2"));
-        Assert.assertEquals("ab\\2", interpret("  \"ab\\\\\" + 2"));
+        Assertions.assertEquals("ab6cd", interpret("  \"ab\" + 6 + \"cd\" "));
+        Assertions.assertEquals("ab2", interpret("  \"ab\" + 2"));
+        Assertions.assertEquals("ab\"2", interpret("  \"ab\\\"\" + 2"));
+        Assertions.assertEquals("ab\\2", interpret("  \"ab\\\\\" + 2"));
     }
 
     @Test
     public void testBooleanExpression() throws Exception {
-        Assert.assertEquals(true, interpret(" true "));
-        Assert.assertEquals(false, interpret(" false "));
-        Assert.assertEquals(false, interpret(" not true "));
-        Assert.assertEquals(true, interpret(" not false "));
+        Assertions.assertEquals(true, interpret(" true "));
+        Assertions.assertEquals(false, interpret(" false "));
+        Assertions.assertEquals(false, interpret(" not true "));
+        Assertions.assertEquals(true, interpret(" not false "));
 
-        Assert.assertEquals(false, interpret(" false and false "));
-        Assert.assertEquals(false, interpret(" false and true "));
-        Assert.assertEquals(false, interpret(" true and false "));
-        Assert.assertEquals(true, interpret(" true and true "));
+        Assertions.assertEquals(false, interpret(" false and false "));
+        Assertions.assertEquals(false, interpret(" false and true "));
+        Assertions.assertEquals(false, interpret(" true and false "));
+        Assertions.assertEquals(true, interpret(" true and true "));
 
-        Assert.assertEquals(false, interpret(" false or false "));
-        Assert.assertEquals(true, interpret(" false or true "));
-        Assert.assertEquals(true, interpret(" true or false "));
-        Assert.assertEquals(true, interpret(" true or true "));
+        Assertions.assertEquals(false, interpret(" false or false "));
+        Assertions.assertEquals(true, interpret(" false or true "));
+        Assertions.assertEquals(true, interpret(" true or false "));
+        Assertions.assertEquals(true, interpret(" true or true "));
 
-        Assert.assertEquals(false, interpret(" not true or not true "));
-        Assert.assertEquals(true, interpret(" not false or not true "));
-        Assert.assertEquals(true, interpret(" not true or not false "));
-        Assert.assertEquals(true, interpret(" not false or not false "));
+        Assertions.assertEquals(false, interpret(" not true or not true "));
+        Assertions.assertEquals(true, interpret(" not false or not true "));
+        Assertions.assertEquals(true, interpret(" not true or not false "));
+        Assertions.assertEquals(true, interpret(" not false or not false "));
     }
 
     @Test
     public void testBooleanShortcuts() throws Exception {
-        Assert.assertEquals(1, interpret(" def a = 1 ; a == 0 and a=2 ; a "));
-        Assert.assertEquals(2, interpret(" def a = 1 ; a == 0 or a=2 ; a "));
-        Assert.assertEquals(2, interpret(" def a = 1 ; a == 1 and a=2 ; a "));
-        Assert.assertEquals(1, interpret(" def a = 1 ; a == 1 or a=2 ; a "));
+        Assertions.assertEquals(1, interpret(" def a = 1 ; a == 0 and a=2 ; a "));
+        Assertions.assertEquals(2, interpret(" def a = 1 ; a == 0 or a=2 ; a "));
+        Assertions.assertEquals(2, interpret(" def a = 1 ; a == 1 and a=2 ; a "));
+        Assertions.assertEquals(1, interpret(" def a = 1 ; a == 1 or a=2 ; a "));
     }
 
     @Test
     public void testComp() throws Exception {
-        Assert.assertEquals(true, interpret("  def a = 1 ; def b = 2 ; a < b"));
-        Assert.assertEquals(true, interpret("  def a = 1 ; def b = 2 ; a <= b"));
-        Assert.assertEquals(false, interpret("  def a = 1 ; def b = 2 ; a == b"));
-        Assert.assertEquals(true, interpret("  def a = 1 ; def b = 1 ; a == b"));
-        Assert.assertEquals(true, interpret("  def a = 1 ; def b = 2 ; a != b"));
-        Assert.assertEquals(false, interpret("  def a = 1 ; def b = 1 ; a != b"));
-        Assert.assertEquals(false, interpret("  def a = '1' ; def b = '2' ; a == b"));
-        Assert.assertEquals(true, interpret("  def a = '1' ; def b = '1' ; a == b"));
-        Assert.assertEquals(true, interpret("  def a = '1' ; def b = '2' ; a != b"));
-        Assert.assertEquals(false, interpret("  def a = '1' ; def b = '1' ; a != b"));
-        Assert.assertEquals(false, interpret("  def a = 1 ; def b = 2 ; a >= b"));
-        Assert.assertEquals(false, interpret("  def a = 1 ; def b = 2 ; a > b"));
+        Assertions.assertEquals(true, interpret("  def a = 1 ; def b = 2 ; a < b"));
+        Assertions.assertEquals(true, interpret("  def a = 1 ; def b = 2 ; a <= b"));
+        Assertions.assertEquals(false, interpret("  def a = 1 ; def b = 2 ; a == b"));
+        Assertions.assertEquals(true, interpret("  def a = 1 ; def b = 1 ; a == b"));
+        Assertions.assertEquals(true, interpret("  def a = 1 ; def b = 2 ; a != b"));
+        Assertions.assertEquals(false, interpret("  def a = 1 ; def b = 1 ; a != b"));
+        Assertions.assertEquals(false, interpret("  def a = '1' ; def b = '2' ; a == b"));
+        Assertions.assertEquals(true, interpret("  def a = '1' ; def b = '1' ; a == b"));
+        Assertions.assertEquals(true, interpret("  def a = '1' ; def b = '2' ; a != b"));
+        Assertions.assertEquals(false, interpret("  def a = '1' ; def b = '1' ; a != b"));
+        Assertions.assertEquals(false, interpret("  def a = 1 ; def b = 2 ; a >= b"));
+        Assertions.assertEquals(false, interpret("  def a = 1 ; def b = 2 ; a > b"));
 
-        Assert.assertEquals(false, interpret("  def a = 1 ; def b = 2 ; b < a"));
-        Assert.assertEquals(false, interpret("  def a = 1 ; def b = 2 ; b <= a"));
-        Assert.assertEquals(true, interpret("  def a = 1 ; def b = 1 ; b == a"));
-        Assert.assertEquals(true, interpret("  def a = 1 ; def b = 2 ; b >= a"));
-        Assert.assertEquals(true, interpret("  def a = 1 ; def b = 2 ; b > a"));
+        Assertions.assertEquals(false, interpret("  def a = 1 ; def b = 2 ; b < a"));
+        Assertions.assertEquals(false, interpret("  def a = 1 ; def b = 2 ; b <= a"));
+        Assertions.assertEquals(true, interpret("  def a = 1 ; def b = 1 ; b == a"));
+        Assertions.assertEquals(true, interpret("  def a = 1 ; def b = 2 ; b >= a"));
+        Assertions.assertEquals(true, interpret("  def a = 1 ; def b = 2 ; b > a"));
 
-        Assert.assertEquals(true, interpret("  \"a\" == \"a\""));
-        Assert.assertEquals(false, interpret("  \"b\" >  \"c\""));
-        Assert.assertEquals(true, interpret("  \"b\" >  \"a\""));
+        Assertions.assertEquals(true, interpret("  \"a\" == \"a\""));
+        Assertions.assertEquals(false, interpret("  \"b\" >  \"c\""));
+        Assertions.assertEquals(true, interpret("  \"b\" >  \"a\""));
     }
 }

--- a/src/test/java/org/babblelang/tests/BabbleFunctionsTestCase.java
+++ b/src/test/java/org/babblelang/tests/BabbleFunctionsTestCase.java
@@ -1,89 +1,89 @@
 package org.babblelang.tests;
 
 import org.babblelang.engine.impl.Function;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.script.ScriptException;
 
 public class BabbleFunctionsTestCase extends BabbleTestBase {
     @Test
     public void testFunctionLiteral() throws Exception {
-        Assert.assertTrue(interpret("def add = (a:int, b:int):int -> ( a + b )") instanceof Function);
+        Assertions.assertTrue(interpret("def add = (a:int, b:int):int -> ( a + b )") instanceof Function);
     }
 
     @Test
     public void testFunctionCall() throws Exception {
-        Assert.assertEquals(2, interpret("def add = (a:int, b:int):int -> ( a + b ) ; add(1,1)"));
-        Assert.assertEquals("ab", interpret("def add = (a, b) -> ( a + b ) ; add(\"a\",\"b\")"));
+        Assertions.assertEquals(2, interpret("def add = (a:int, b:int):int -> ( a + b ) ; add(1,1)"));
+        Assertions.assertEquals("ab", interpret("def add = (a, b) -> ( a + b ) ; add(\"a\",\"b\")"));
     }
 
     @Test
     public void testParameterPassing() throws Exception {
-        Assert.assertEquals("ab", interpret("def add = (a, b) -> ( a + b ) ; add(a:\"a\",b:\"b\")"));
-        Assert.assertEquals("ba", interpret("def add = (a, b) -> ( a + b ) ; add(b:\"a\",a:\"b\")"));
+        Assertions.assertEquals("ab", interpret("def add = (a, b) -> ( a + b ) ; add(a:\"a\",b:\"b\")"));
+        Assertions.assertEquals("ba", interpret("def add = (a, b) -> ( a + b ) ; add(b:\"a\",a:\"b\")"));
 
         try {
-            Assert.assertEquals("ba", interpret("def add = (a, b) -> ( a + b ) ; add(b:\"a\")"));
-            Assert.fail("Should report missing parameter");
+            Assertions.assertEquals("ba", interpret("def add = (a, b) -> ( a + b ) ; add(b:\"a\")"));
+            Assertions.fail("Should report missing parameter");
         } catch (ScriptException e) {
-            Assert.assertEquals("org.babblelang.engine.BabbleException: Missing parameter : a in <input> at line number 1", e.getMessage());
+            Assertions.assertEquals("org.babblelang.engine.BabbleException: Missing parameter : a in <input> at line number 1", e.getMessage());
         }
     }
 
     @Test
     public void testCallableError() {
         try {
-            Assert.assertEquals(null, interpret("def add = (a, b) -> ( a + b ) ; add(a:\"a\",b:\"b\")(\"foobar\")"));
-            Assert.fail("Should report not callable expression");
+            Assertions.assertEquals(null, interpret("def add = (a, b) -> ( a + b ) ; add(a:\"a\",b:\"b\")(\"foobar\")"));
+            Assertions.fail("Should report not callable expression");
         } catch (ScriptException e) {
-            Assert.assertEquals("org.babblelang.engine.BabbleException: add(a:\"a\",b:\"b\") is not callable in <input> at line number 1", e.getMessage());
+            Assertions.assertEquals("org.babblelang.engine.BabbleException: add(a:\"a\",b:\"b\") is not callable in <input> at line number 1", e.getMessage());
         }
     }
 
     @Test
     public void testParameterPassingWithDefaults() throws Exception {
-        Assert.assertEquals("ab", interpret("def add = (a=\"hello\", b) -> ( a + b ) ; add(a:\"a\",b:\"b\")"));
-        Assert.assertEquals("hellob", interpret("def add = (a=\"hello\", b) -> ( a + b ) ; add(b:\"b\")"));
-        Assert.assertEquals("ahello", interpret("def add = (a, b=\"hello\") -> ( a + b ) ; add(\"a\")"));
-        Assert.assertEquals("hello world", interpret("def add = (a=\"hello\", b=\" world\") -> ( a + b ) ; add()"));
+        Assertions.assertEquals("ab", interpret("def add = (a=\"hello\", b) -> ( a + b ) ; add(a:\"a\",b:\"b\")"));
+        Assertions.assertEquals("hellob", interpret("def add = (a=\"hello\", b) -> ( a + b ) ; add(b:\"b\")"));
+        Assertions.assertEquals("ahello", interpret("def add = (a, b=\"hello\") -> ( a + b ) ; add(\"a\")"));
+        Assertions.assertEquals("hello world", interpret("def add = (a=\"hello\", b=\" world\") -> ( a + b ) ; add()"));
 
         try {
-            Assert.assertEquals("ba", interpret("def add = (a=\"b\", b) -> ( a + b ) ; add(a:\"a\")"));
-            Assert.fail("Should report \"Missing parameter : b\"");
+            Assertions.assertEquals("ba", interpret("def add = (a=\"b\", b) -> ( a + b ) ; add(a:\"a\")"));
+            Assertions.fail("Should report \"Missing parameter : b\"");
         } catch (ScriptException e) {
-            Assert.assertEquals("org.babblelang.engine.BabbleException: Missing parameter : b in <input> at line number 1", e.getMessage());
+            Assertions.assertEquals("org.babblelang.engine.BabbleException: Missing parameter : b in <input> at line number 1", e.getMessage());
         }
     }
 
     @Test
     public void testParameterPassingWithFunctionDefaults() throws Exception {
-        Assert.assertEquals(1, interpret("def apply = (a, f=(v) -> (v)) -> ( f(a) ) ; apply(1)"));
-        Assert.assertEquals(2, interpret("def apply = (a, f=(v) -> (v+1)) -> ( f(a) ) ; apply(1)"));
+        Assertions.assertEquals(1, interpret("def apply = (a, f=(v) -> (v)) -> ( f(a) ) ; apply(1)"));
+        Assertions.assertEquals(2, interpret("def apply = (a, f=(v) -> (v+1)) -> ( f(a) ) ; apply(1)"));
     }
 
     @Test
     public void testFunctionScope() throws Exception {
-        Assert.assertEquals(102, interpret("def a = 99 ; def add = (a:int, b:int):int -> ( a = a + 1 ; a + b ) ; add(1,1) + a"));
+        Assertions.assertEquals(102, interpret("def a = 99 ; def add = (a:int, b:int):int -> ( a = a + 1 ; a + b ) ; add(1,1) + a"));
     }
 
     @Test
     public void testClosureScope() throws Exception {
-        Assert.assertEquals(2005, interpret("def a = 99 ; def c = 1000; def adder = (a:int):(b:int):int -> ( (b:int):int -> ( a + b + c) ) ; def plus1 = adder(1) ; plus1(1) + plus1(2)"));
+        Assertions.assertEquals(2005, interpret("def a = 99 ; def c = 1000; def adder = (a:int):(b:int):int -> ( (b:int):int -> ( a + b + c) ) ; def plus1 = adder(1) ; plus1(1) + plus1(2)"));
     }
 
     @Test
     public void testClosureMemory() throws Exception {
-        Assert.assertEquals(2005, interpret("def a = 99 ; def c = 1000; def adder = (a:int,d:int):(b:int):int -> ( (b:int):int -> ( a + b + c ) ) ; def plus1 = adder(1,0) ; plus1(1) + plus1(2)"));
+        Assertions.assertEquals(2005, interpret("def a = 99 ; def c = 1000; def adder = (a:int,d:int):(b:int):int -> ( (b:int):int -> ( a + b + c ) ) ; def plus1 = adder(1,0) ; plus1(1) + plus1(2)"));
     }
 
     @Test
     public void testRecursion() throws Exception {
-        Assert.assertEquals(120, interpret("def fac = (n:int):int -> ( if(n<=1) then ( 1 ) else ( n * recurse(n-1) ) ) ; fac(5)"));
+        Assertions.assertEquals(120, interpret("def fac = (n:int):int -> ( if(n<=1) then ( 1 ) else ( n * recurse(n-1) ) ) ; fac(5)"));
     }
 
     @Test
     public void testMutualRecursion() throws Exception {
-        Assert.assertEquals(720, interpret("def fac = (n:int):int -> ( if(n<=1) then ( 1 ) else ( n * fac2(n-1) ) ) ; def fac2 = (n:int):int -> ( if(n<=1) then ( 1 ) else ( n * fac(n-1) ) ) ; fac(6)"));
+        Assertions.assertEquals(720, interpret("def fac = (n:int):int -> ( if(n<=1) then ( 1 ) else ( n * fac2(n-1) ) ) ; def fac2 = (n:int):int -> ( if(n<=1) then ( 1 ) else ( n * fac(n-1) ) ) ; fac(6)"));
     }
 }

--- a/src/test/java/org/babblelang/tests/BabbleNativesTestCase.java
+++ b/src/test/java/org/babblelang/tests/BabbleNativesTestCase.java
@@ -1,18 +1,18 @@
 package org.babblelang.tests;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class BabbleNativesTestCase extends BabbleTestBase {
     @Test
     public void testGlobalScope() throws Exception {
-        Assert.assertEquals("ok", interpret("if STDOUT then ( \"ok\" ) else ( \"ko\") "));
-        Assert.assertEquals("ok", interpret("if print then ( \"ok\" ) else ( \"ko\") "));
-        Assert.assertEquals("ok", interpret("if println then ( \"ok\" ) else ( \"ko\") "));
+        Assertions.assertEquals("ok", interpret("if STDOUT then ( \"ok\" ) else ( \"ko\") "));
+        Assertions.assertEquals("ok", interpret("if print then ( \"ok\" ) else ( \"ko\") "));
+        Assertions.assertEquals("ok", interpret("if println then ( \"ok\" ) else ( \"ko\") "));
     }
 
     @Test
     public void testNativeCallScope() throws Exception {
-        Assert.assertEquals(null, interpret("println (\"Hello\", \", world ! 1+1=\", 1 + 1)"));
+        Assertions.assertEquals(null, interpret("println (\"Hello\", \", world ! 1+1=\", 1 + 1)"));
     }
 }

--- a/src/test/java/org/babblelang/tests/BabbleScopesTestCase.java
+++ b/src/test/java/org/babblelang/tests/BabbleScopesTestCase.java
@@ -1,89 +1,89 @@
 package org.babblelang.tests;
 
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import javax.script.ScriptException;
 
 public class BabbleScopesTestCase extends BabbleTestBase {
     @Test
     public void testPackageScope() throws Exception {
-        Assert.assertEquals(2, interpret("package test ( def value = 1 ) ; test.value + 1"));
-        Assert.assertEquals(6, interpret("package test ( def value = 1 ; package test2 ( def value = 3 ) ; value = value + 1 ) ; test.value + test.test2.value + 1"));
+        Assertions.assertEquals(2, interpret("package test ( def value = 1 ) ; test.value + 1"));
+        Assertions.assertEquals(6, interpret("package test ( def value = 1 ; package test2 ( def value = 3 ) ; value = value + 1 ) ; test.value + test.test2.value + 1"));
     }
 
     @Test
     public void testIncr() throws Exception {
-        Assert.assertEquals(2, interpret("def i = 0 ; ( i = i + 1 ) ; i = i + 1 ; i"));
+        Assertions.assertEquals(2, interpret("def i = 0 ; ( i = i + 1 ) ; i = i + 1 ; i"));
     }
 
     @Test
     public void testPrecedence() throws Exception {
-        Assert.assertEquals(2, interpret("def value = 1; value = value + 1 ; value"));
-        Assert.assertEquals(2, interpret("package test (def value = 1) ; def value = test.value + 1 ; value"));
-        Assert.assertEquals(1, interpret("package test (def value = 1) ; def value ; value = test.value ; value"));
+        Assertions.assertEquals(2, interpret("def value = 1; value = value + 1 ; value"));
+        Assertions.assertEquals(2, interpret("package test (def value = 1) ; def value = test.value + 1 ; value"));
+        Assertions.assertEquals(1, interpret("package test (def value = 1) ; def value ; value = test.value ; value"));
     }
 
     @Test
     public void testDef() throws Exception {
-        Assert.assertEquals(null, interpret("def i"));
-        Assert.assertEquals(null, interpret("def i ; i"));
-        Assert.assertEquals(1, interpret("def i ; i = 1"));
-        Assert.assertEquals(1, interpret("def i ; i = 1 ; i"));
+        Assertions.assertEquals(null, interpret("def i"));
+        Assertions.assertEquals(null, interpret("def i ; i"));
+        Assertions.assertEquals(1, interpret("def i ; i = 1"));
+        Assertions.assertEquals(1, interpret("def i ; i = 1 ; i"));
     }
 
     @Test
     public void testAssign() throws Exception {
-        Assert.assertEquals(0, interpret("def i = 0 ; i"));
-        Assert.assertEquals(1, interpret("def i = 0 ; i = 1"));
-        Assert.assertEquals(2, interpret("def i = 0 ; i = 1 ; i = i + 1"));
-        Assert.assertEquals(2, interpret("def i = 0 ; i = 1 ; i = i + 1 ; i"));
+        Assertions.assertEquals(0, interpret("def i = 0 ; i"));
+        Assertions.assertEquals(1, interpret("def i = 0 ; i = 1"));
+        Assertions.assertEquals(2, interpret("def i = 0 ; i = 1 ; i = i + 1"));
+        Assertions.assertEquals(2, interpret("def i = 0 ; i = 1 ; i = i + 1 ; i"));
     }
 
-    @Ignore("Block scope is not implemented yet")
+    @Disabled("Block scope is not implemented yet")
     @Test
     public void testBlockScope() throws Exception {
         try {
-            Assert.assertEquals(2, interpret("def a = 1 ; (def b = 2) ; a ; b"));
-            Assert.fail("Should report \"No such key : b\"");
+            Assertions.assertEquals(2, interpret("def a = 1 ; (def b = 2) ; a ; b"));
+            Assertions.fail("Should report \"No such key : b\"");
         } catch (IllegalArgumentException e) {
-            Assert.assertEquals("No such key : b", e.getMessage());
+            Assertions.assertEquals("No such key : b", e.getMessage());
         }
 
         try {
-            Assert.assertEquals("ba", interpret("def a = 1 ; (def b = 2) ; a = 1 ; b = 5"));
-            Assert.fail("Should report \"No such key : b\"");
+            Assertions.assertEquals("ba", interpret("def a = 1 ; (def b = 2) ; a = 1 ; b = 5"));
+            Assertions.fail("Should report \"No such key : b\"");
         } catch (IllegalArgumentException e) {
-            Assert.assertEquals("No such key : b", e.getMessage());
+            Assertions.assertEquals("No such key : b", e.getMessage());
         }
 
         try {
-            Assert.assertEquals("ba", interpret("def a = 1 ; def a = 2"));
-            Assert.fail("Should report \"Key already defined : a\"");
+            Assertions.assertEquals("ba", interpret("def a = 1 ; def a = 2"));
+            Assertions.fail("Should report \"Key already defined : a\"");
         } catch (IllegalArgumentException e) {
-            Assert.assertEquals("Key already defined : a", e.getMessage());
+            Assertions.assertEquals("Key already defined : a", e.getMessage());
         }
     }
 
     @Test
     public void testBlockResult() throws Exception {
-        Assert.assertEquals(6, interpret("( 1 + 2 + 3 )"));
-        Assert.assertEquals(3, interpret("( 1 ; 2 ; 3 )"));
-        Assert.assertEquals(3, interpret("( 1 \n 2 \n 3 )"));
+        Assertions.assertEquals(6, interpret("( 1 + 2 + 3 )"));
+        Assertions.assertEquals(3, interpret("( 1 ; 2 ; 3 )"));
+        Assertions.assertEquals(3, interpret("( 1 \n 2 \n 3 )"));
     }
 
     @Test
     public void testNewlineEndsStatement() throws Exception {
         // under the old grammar this parsed as the call 1(a + 1)
-        Assert.assertEquals(2, interpret("def a = 1 \n ( a + 1 )"));
+        Assertions.assertEquals(2, interpret("def a = 1 \n ( a + 1 )"));
     }
 
     @Test
     public void testJuxtapositionIsRejected() throws Exception {
         try {
             interpret("( 1  2 3 )");
-            Assert.fail("Statements on the same line require a ';' separator");
+            Assertions.fail("Statements on the same line require a ';' separator");
         } catch (ScriptException e) {
             // expected : juxtaposition without ';' or newline is a parse error
         }

--- a/src/test/java/org/babblelang/tests/BabbleTestBase.java
+++ b/src/test/java/org/babblelang/tests/BabbleTestBase.java
@@ -1,15 +1,12 @@
 package org.babblelang.tests;
 
 import org.babblelang.engine.BabbleScriptEngineFactory;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 import javax.script.Bindings;
 import javax.script.ScriptException;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 
-@RunWith(JUnit4.class)
 public abstract class BabbleTestBase {
     private Bindings buildBindings() {
         Bindings b = BabbleScriptEngineFactory.INSTANCE.getScriptEngine().createBindings();

--- a/src/test/java/org/babblelang/tests/OptimizerTestBase.java
+++ b/src/test/java/org/babblelang/tests/OptimizerTestBase.java
@@ -4,11 +4,8 @@ import org.antlr.v4.runtime.*;
 import org.babblelang.parser.BabbleBaseVisitor;
 import org.babblelang.parser.BabbleLexer;
 import org.babblelang.parser.BabbleParser;
-import org.junit.Assert;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Assertions;
 
-@RunWith(JUnit4.class)
 public abstract class OptimizerTestBase {
 
     private BabbleParser.FileContext parse(String code) {
@@ -30,6 +27,6 @@ public abstract class OptimizerTestBase {
         if (modifier != null) {
             modifier.visitFile(tree2);
         }
-        Assert.assertEquals(code1 + " is not equivalent to " + code2 + " after applying " + modifier, tree1.getText(), tree2.getText());
+        Assertions.assertEquals(tree1.getText(), tree2.getText(), code1 + " is not equivalent to " + code2 + " after applying " + modifier);
     }
 }

--- a/src/test/java/org/babblelang/tests/OptimizerTestTest.java
+++ b/src/test/java/org/babblelang/tests/OptimizerTestTest.java
@@ -1,6 +1,9 @@
 package org.babblelang.tests;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests for the optimizer testing framework.
@@ -17,13 +20,13 @@ public class OptimizerTestTest extends OptimizerTestBase {
         assertEquivalent("\"coucou\" + 0", "\"coucou\"-2", new StupidOptimizer());
     }
 
-    @Test(expected = org.junit.ComparisonFailure.class)
+    @Test
     public void testDifference1() {
-        assertEquivalent("1 + 0", "1+1");
+        assertThrows(AssertionFailedError.class, () -> assertEquivalent("1 + 0", "1+1"));
     }
 
-    @Test(expected = org.junit.ComparisonFailure.class)
+    @Test
     public void testDifference2() {
-        assertEquivalent("1 + 0", "1+1", new StupidOptimizer());
+        assertThrows(AssertionFailedError.class, () -> assertEquivalent("1 + 0", "1+1", new StupidOptimizer()));
     }
 }

--- a/src/test/java/org/babblelang/tests/ScriptTestCase.java
+++ b/src/test/java/org/babblelang/tests/ScriptTestCase.java
@@ -6,29 +6,26 @@ import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.babblelang.parser.BabbleLexer;
 import org.babblelang.parser.BabbleParser;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 
-@RunWith(Parameterized.class)
 public class ScriptTestCase extends BabbleTestBase {
 
-    @Parameterized.Parameters(name = "{0}")
-    public static Collection<Object[]> data() {
+    static Collection<String> data() {
         File file = new File("src/test/babble");
-        Assert.assertTrue(file.isDirectory());
+        Assertions.assertTrue(file.isDirectory());
         return findBaFiles(file, new ArrayList<>());
     }
 
-    private static Collection<Object[]> findBaFiles(File base, ArrayList<Object[]> result) {
+    private static Collection<String> findBaFiles(File base, ArrayList<String> result) {
         if (base.isFile()) {
             if (base.getName().endsWith(".ba")) {
-                result.add(new Object[]{base.getPath().replace(File.separatorChar, '/')});
+                result.add(base.getPath().replace(File.separatorChar, '/'));
             }
         } else {
             File[] files = base.listFiles();
@@ -41,14 +38,9 @@ public class ScriptTestCase extends BabbleTestBase {
         return result;
     }
 
-    private final String file;
-
-    public ScriptTestCase(String file) {
-        this.file = file;
-    }
-
-    @Test
-    public void parse() throws Exception {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("data")
+    public void parse(String file) throws Exception {
         CharStream input = CharStreams.fromFileName(file);
         BabbleLexer lexer = new BabbleLexer(input);
         CommonTokenStream tokenStream = new CommonTokenStream(lexer);
@@ -57,8 +49,9 @@ public class ScriptTestCase extends BabbleTestBase {
         parser.file();
     }
 
-    @Test
-    public void run() throws Exception {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("data")
+    public void run(String file) throws Exception {
         interpretFile(file);
     }
 }

--- a/src/test/java/org/babblelang/tests/SimpleBinaryOpsOptimizerTest.java
+++ b/src/test/java/org/babblelang/tests/SimpleBinaryOpsOptimizerTest.java
@@ -1,7 +1,7 @@
 package org.babblelang.tests;
 
 import org.babblelang.engine.optimizer.SimpleBinaryOpsOptimizer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SimpleBinaryOpsOptimizerTest extends OptimizerTestBase {
     @Test


### PR DESCRIPTION
Moves the build off Java 8 / JUnit 4 and refreshes the CI actions. No functional change to the language or interpreter — main sources are untouched.

## Build

- Java `release` 8 → 21, via a `maven.compiler.release` property
- JUnit 4.13.2 → `junit-jupiter` 6.1.2
- Surefire pinned at 3.5.6 (it was previously resolving implicitly)
- ANTLR and JUnit versions hoisted into `<properties>`

## CI

- Both workflows to JDK 21
- Off the deprecated action versions: `checkout@v3→v4`, `setup-java@v3→v4`, `codeql-action@v2→v3`
- The CodeQL job had **no** `setup-java` step and relied on the runner's default JDK. That would break autobuild against a `release 21` pom if the default ever regressed, so it now pins 21 explicitly.

## Test migration — the parts that weren't mechanical

Most of the test diff is imports, `@Ignore`→`@Disabled`, and dropping `@RunWith(JUnit4.class)`. Three spots needed real thought and are worth reviewing:

1. **`ScriptTestCase`** — JUnit 5 has no `Parameterized` equivalent, so constructor injection became `@ParameterizedTest` + `@MethodSource`, with the provider returning `Collection<String>` instead of `Collection<Object[]>`.

2. **Argument order flip** — Jupiter puts the assertion message *last*. This is the silent-breakage risk in a 4→5 migration: `assertEquals(msg, a, b)` still compiles as `assertEquals(expected, actual, msg)` and compares the wrong things. Two sites had message-first form (`OptimizerTestBase`, `AssertFunction`); both reordered.

3. **`AssertFunction`** — this caught a real failure. Jupiter's `assertTrue` appends `==> expected: <true> but was: <false>` to the message, but `BabbleEnvironmentTestCase` asserts the *exact* text Babble's `assert` builtin reports. Rather than loosen that to a substring match, the test function now throws `AssertionFailedError` with the verbatim message — preserving JUnit 4 behavior and keeping the test's actual intent (verifying Babble's error text).

`OptimizerTestTest`'s `@Test(expected = ComparisonFailure.class)` became `assertThrows(AssertionFailedError.class, ...)`, since Jupiter throws opentest4j types.

## Verification

`mvn clean package` on `maven:3.9-eclipse-temurin-21`: **61 tests run, 0 failures, 1 skipped** — identical counts to the JUnit 4 baseline, so nothing was silently dropped. Main sources compile clean at `release 21` with no deprecation warnings.

The workflow changes themselves are only verified once CI runs on this PR.

## Not included

Per the chosen scope, the 24 main-source files keep their Java 8 idioms. `Slot` and `Parameters` look like natural record candidates if an idiomatic pass is wanted later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)