### PR TITLE
Modernize main sources to Java 21 idioms

### DIFF
--- a/src/main/java/org/babblelang/engine/BabbleScriptEngineFactory.java
+++ b/src/main/java/org/babblelang/engine/BabbleScriptEngineFactory.java
@@ -2,7 +2,6 @@ package org.babblelang.engine;
 
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineFactory;
-import java.util.Collections;
 import java.util.List;
 
 public class BabbleScriptEngineFactory implements ScriptEngineFactory {
@@ -17,15 +16,15 @@ public class BabbleScriptEngineFactory implements ScriptEngineFactory {
     }
 
     public List<String> getExtensions() {
-        return Collections.singletonList("ba");
+        return List.of("ba");
     }
 
     public List<String> getMimeTypes() {
-        return Collections.singletonList("application/x-babble");
+        return List.of("application/x-babble");
     }
 
     public List<String> getNames() {
-        return Collections.singletonList("babble");
+        return List.of("babble");
     }
 
     public String getLanguageName() {
@@ -41,19 +40,7 @@ public class BabbleScriptEngineFactory implements ScriptEngineFactory {
     }
 
     public String getMethodCallSyntax(String obj, String m, String... args) {
-        StringBuilder buffer = new StringBuilder();
-        buffer.append(obj);
-        buffer.append('.');
-        buffer.append(m);
-        buffer.append('(');
-        for (int i = 0, l = args.length; i < l; i++) {
-            if (i > 0) {
-                buffer.append(',');
-            }
-            buffer.append(args[i]);
-        }
-        buffer.append(')');
-        return buffer.toString();
+        return obj + '.' + m + '(' + String.join(",", args) + ')';
     }
 
     public String getOutputStatement(String toDisplay) {
@@ -61,14 +48,7 @@ public class BabbleScriptEngineFactory implements ScriptEngineFactory {
     }
 
     public String getProgram(String... statements) {
-        StringBuilder buffer = new StringBuilder();
-        for (int i = 0, l = statements.length; i < l; i++) {
-            if (i > 0) {
-                buffer.append('\n');
-            }
-            buffer.append(statements[i]);
-        }
-        return buffer.toString();
+        return String.join("\n", statements);
     }
 
     public ScriptEngine getScriptEngine() {

--- a/src/main/java/org/babblelang/engine/impl/BabbleObject.java
+++ b/src/main/java/org/babblelang/engine/impl/BabbleObject.java
@@ -9,10 +9,9 @@ public class BabbleObject extends Namespace {
     public Slot<Object> get(String key) {
         Slot<Object> result = super.get(key);
         Object value = result.get();
-        if (!locals.containsKey(key) && value instanceof Function) {
-            Function function = (Function) value;
+        if (!locals.containsKey(key) && value instanceof Function<?> function) {
             result = define(key, true);
-            result.set(new BoundMethod(function, this));
+            result.set(new BoundMethod<>(function, this));
         }
         return result;
     }

--- a/src/main/java/org/babblelang/engine/impl/BoundMethod.java
+++ b/src/main/java/org/babblelang/engine/impl/BoundMethod.java
@@ -17,7 +17,7 @@ public class BoundMethod<R> implements Callable<R> {
         return result;
     }
 
-    public R call(Interpreter interpreter, BabbleParser.CallContext callSite, Scope scope) {
+    public R call(Interpreter interpreter, BabbleParser.CallContext callSite, Scope<Object> scope) {
         return function.call(interpreter, callSite, scope);
     }
 }

--- a/src/main/java/org/babblelang/engine/impl/Function.java
+++ b/src/main/java/org/babblelang/engine/impl/Function.java
@@ -18,7 +18,9 @@ public class Function<R> implements Callable<R> {
         return namespace;
     }
 
-    public R call(Interpreter interpreter, BabbleParser.CallContext callSite, Scope scope) {
+    // The interpreter is untyped, so the result type is the caller's assertion.
+    @SuppressWarnings("unchecked")
+    public R call(Interpreter interpreter, BabbleParser.CallContext callSite, Scope<Object> scope) {
         return (R) interpreter.visit(definition.functionBlock);
     }
 }

--- a/src/main/java/org/babblelang/engine/impl/Interpreter.java
+++ b/src/main/java/org/babblelang/engine/impl/Interpreter.java
@@ -41,7 +41,7 @@ public class Interpreter extends BabbleBaseVisitor<Object> {
     @Override
     public Object visitObjectExpression(BabbleParser.ObjectExpressionContext ctx) {
         last = ctx;
-        Scope object = namespace = new BabbleObject(namespace);
+        Scope<Object> object = namespace = new BabbleObject(namespace);
         visit(ctx.createBlock);
         last = ctx;
         namespace = namespace.leave();
@@ -75,11 +75,11 @@ public class Interpreter extends BabbleBaseVisitor<Object> {
     @Override
     public Object visitSelector(BabbleParser.SelectorContext ctx) {
         last = ctx;
-        Scope base = namespace;
+        Scope<?> base = namespace;
         String name = ctx.ID().getText();
         BabbleParser.ExpressionContext expression = ctx.expression();
         if (expression != null) {
-            base = (Scope) visit(expression);
+            base = (Scope<?>) visit(expression);
         }
         last = ctx;
         return base.get(name).get();
@@ -104,85 +104,90 @@ public class Interpreter extends BabbleBaseVisitor<Object> {
         Object b = visit(ctx.right);
         last = ctx;
 
+        // Arms return rather than yield: a switch expression would apply binary numeric
+        // promotion across the arms and turn integer results into doubles.
         switch (ctx.op.getType()) {
-            case BabbleLexer.MUL:
+            case BabbleLexer.MUL -> {
                 // TODO : derive operand types
-                if (a instanceof Integer && b instanceof Integer) {
-                    return (Integer) a * (Integer) b;
-                } else {
-                    return number(a, ctx.left).doubleValue() * number(b, ctx.right).doubleValue();
+                if (a instanceof Integer ia && b instanceof Integer ib) {
+                    return ia * ib;
                 }
+                return number(a, ctx.left).doubleValue() * number(b, ctx.right).doubleValue();
+            }
 
-            case BabbleLexer.DIV:
+            case BabbleLexer.DIV -> {
                 return number(a, ctx.left).doubleValue() / number(b, ctx.right).doubleValue();
+            }
 
-            case BabbleLexer.PLUS:
-                if (a instanceof String) {
-                    return (String) a + b;
-                } else if (a instanceof Integer && b instanceof Integer) {
-                    return (Integer) a + (Integer) b;
-                } else {
-                    return number(a, ctx.left).doubleValue() + number(b, ctx.right).doubleValue();
+            case BabbleLexer.PLUS -> {
+                if (a instanceof String sa) {
+                    return sa + b;
                 }
-
-            case BabbleLexer.MINUS:
-                if (a instanceof Integer && b instanceof Integer) {
-                    return (Integer) a - (Integer) b;
-                } else {
-                    return number(a, ctx.left).doubleValue() - number(b, ctx.right).doubleValue();
+                if (a instanceof Integer ia && b instanceof Integer ib) {
+                    return ia + ib;
                 }
+                return number(a, ctx.left).doubleValue() + number(b, ctx.right).doubleValue();
+            }
 
-            case BabbleLexer.LT:
-                //noinspection unchecked
-                return comparable(a, ctx.left).compareTo(comparable(b, ctx.right)) < 0;
+            case BabbleLexer.MINUS -> {
+                if (a instanceof Integer ia && b instanceof Integer ib) {
+                    return ia - ib;
+                }
+                return number(a, ctx.left).doubleValue() - number(b, ctx.right).doubleValue();
+            }
 
-            case BabbleLexer.LTE:
-                //noinspection unchecked
-                return comparable(a, ctx.left).compareTo(comparable(b, ctx.right)) <= 0;
+            case BabbleLexer.LT -> {
+                return compare(a, b, ctx) < 0;
+            }
 
-            case BabbleLexer.EQ:
+            case BabbleLexer.LTE -> {
+                return compare(a, b, ctx) <= 0;
+            }
+
+            case BabbleLexer.EQ -> {
                 if (a instanceof Comparable) {
-                    //noinspection unchecked
-                    return comparable(a, ctx.left).compareTo(comparable(b, ctx.right)) == 0;
-                } else {
-                    return a == b;
+                    return compare(a, b, ctx) == 0;
                 }
+                return a == b;
+            }
 
-            case BabbleLexer.NEQ:
+            case BabbleLexer.NEQ -> {
                 if (a instanceof Comparable) {
-                    //noinspection unchecked
-                    return comparable(a, ctx.left).compareTo(comparable(b, ctx.right)) != 0;
-                } else {
-                    return a != b;
+                    return compare(a, b, ctx) != 0;
                 }
+                return a != b;
+            }
 
-            case BabbleLexer.GTE:
-                //noinspection unchecked
-                return comparable(a, ctx.left).compareTo(comparable(b, ctx.right)) >= 0;
+            case BabbleLexer.GTE -> {
+                return compare(a, b, ctx) >= 0;
+            }
 
-            case BabbleLexer.GT:
-                //noinspection unchecked
-                return comparable(a, ctx.left).compareTo(comparable(b, ctx.right)) > 0;
+            case BabbleLexer.GT -> {
+                return compare(a, b, ctx) > 0;
+            }
 
-            default:
-                throw new IllegalStateException("Bad op : " + ctx.op.getText());
+            default -> throw new IllegalStateException("Bad op : " + ctx.op.getText());
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private int compare(Object a, Object b, BabbleParser.BinaryOpContext ctx) {
+        return comparable(a, ctx.left).compareTo(comparable(b, ctx.right));
     }
 
     private Number number(Object a, BabbleParser.ExpressionContext expr) {
-        if (a instanceof Number) {
-            return (Number) a;
-        } else {
-            throw new BabbleException("Not a number : " + expr.getText());
+        if (a instanceof Number n) {
+            return n;
         }
+        throw new BabbleException("Not a number : " + expr.getText());
     }
 
-    private Comparable comparable(Object a, BabbleParser.ExpressionContext expr) {
+    private Comparable<Object> comparable(Object a, BabbleParser.ExpressionContext expr) {
         if (a instanceof Comparable) {
-            return (Comparable) a;
-        } else {
-            throw new BabbleException("Not comparable : " + expr.getText());
+            //noinspection unchecked
+            return (Comparable<Object>) a;
         }
+        throw new BabbleException("Not comparable : " + expr.getText());
     }
 
     @Override
@@ -213,10 +218,10 @@ public class Interpreter extends BabbleBaseVisitor<Object> {
     }
 
     private boolean truth(Object value) {
-        if (value instanceof Boolean) {
-            return (Boolean) value;
-        } else if (value instanceof Number) {
-            return ((Number) value).doubleValue() != 0.0;
+        if (value instanceof Boolean bool) {
+            return bool;
+        } else if (value instanceof Number number) {
+            return number.doubleValue() != 0.0;
         } else {
             return value != null;
         }
@@ -291,7 +296,7 @@ public class Interpreter extends BabbleBaseVisitor<Object> {
     @Override
     public Object visitFunctionLiteral(BabbleParser.FunctionLiteralContext ctx) {
         last = ctx;
-        return new Function(ctx, namespace);
+        return new Function<>(ctx, namespace);
     }
 
     @Override
@@ -299,10 +304,9 @@ public class Interpreter extends BabbleBaseVisitor<Object> {
         last = ctx;
         Object expr = visit(ctx.expression());
         last = ctx;
-        if (!(expr instanceof Callable)) {
+        if (!(expr instanceof Callable<?> callable)) {
             throw new BabbleException(ctx.expression().getText() + " is not callable");
         }
-        Callable callable = (Callable) expr;
         Parameters params = (Parameters) visit(ctx.callParameters());
         last = ctx;
         Namespace beforeCall = namespace;

--- a/src/main/java/org/babblelang/engine/impl/Parameters.java
+++ b/src/main/java/org/babblelang/engine/impl/Parameters.java
@@ -26,21 +26,10 @@ public class Parameters extends LinkedHashMap<String, Object> {
     }
 
     public Object[] valuesArray() {
-        Object[] result = new Object[size()];
-        int i = 0;
-        for (Object o : values()) {
-            result[i++] = o;
-        }
-        return result;
+        return values().toArray();
     }
 
-    public Class[] typesArray() {
-        Class[] result = new Class[size()];
-        int i = 0;
-        for (Object o : values()) {
-            result[i++] = o.getClass();
-        }
-        return result;
-
+    public Class<?>[] typesArray() {
+        return values().stream().map(Object::getClass).toArray(Class<?>[]::new);
     }
 }

--- a/src/main/java/org/babblelang/engine/impl/natives/PrintFunction.java
+++ b/src/main/java/org/babblelang/engine/impl/natives/PrintFunction.java
@@ -5,7 +5,7 @@ import org.babblelang.parser.BabbleParser;
 
 import java.io.PrintStream;
 
-public class PrintFunction implements Callable {
+public class PrintFunction implements Callable<Object> {
     private final boolean newLine;
 
     public PrintFunction(boolean newLine) {
@@ -18,7 +18,7 @@ public class PrintFunction implements Callable {
         return namespace;
     }
 
-    public Object call(Interpreter interpreter, BabbleParser.CallContext callSite, Scope scope) {
+    public Object call(Interpreter interpreter, BabbleParser.CallContext callSite, Scope<Object> scope) {
         Parameters params = (Parameters) scope.get("parameters").get();
 
         PrintStream ps = (PrintStream) params.remove("to");

--- a/src/main/java/org/babblelang/engine/impl/natives/java/BoundJavaMethod.java
+++ b/src/main/java/org/babblelang/engine/impl/natives/java/BoundJavaMethod.java
@@ -3,7 +3,7 @@ package org.babblelang.engine.impl.natives.java;
 import org.babblelang.engine.impl.*;
 import org.babblelang.parser.BabbleParser;
 
-public class BoundJavaMethod implements Callable {
+public class BoundJavaMethod implements Callable<Object> {
     private final JavaMethod method;
     private final Object thiz;
 
@@ -18,7 +18,7 @@ public class BoundJavaMethod implements Callable {
         return result;
     }
 
-    public Object call(Interpreter interpreter, BabbleParser.CallContext callSite, Scope scope) {
+    public Object call(Interpreter interpreter, BabbleParser.CallContext callSite, Scope<Object> scope) {
         return method.call(interpreter, callSite, scope);
     }
 }

--- a/src/main/java/org/babblelang/engine/impl/natives/java/ImportFunction.java
+++ b/src/main/java/org/babblelang/engine/impl/natives/java/ImportFunction.java
@@ -16,7 +16,7 @@ public class ImportFunction implements Callable<JavaPackage> {
         return namespace;
     }
 
-    public JavaPackage call(Interpreter interpreter, BabbleParser.CallContext callSite, Scope scope) {
+    public JavaPackage call(Interpreter interpreter, BabbleParser.CallContext callSite, Scope<Object> scope) {
         String name = (String) scope.get("name").get();
         return getPackage(name);
     }

--- a/src/main/java/org/babblelang/engine/impl/natives/java/JavaClass.java
+++ b/src/main/java/org/babblelang/engine/impl/natives/java/JavaClass.java
@@ -11,18 +11,17 @@ import java.util.HashMap;
 import java.util.Map;
 
 class JavaClass implements Scope<Callable>, Callable<JavaObject> {
-    private final Class clazz;
+    private final Class<?> clazz;
     private final Map<String, Slot<Callable>> members = new HashMap<>();
 
-    JavaClass(Class clazz) {
+    JavaClass(Class<?> clazz) {
         this.clazz = clazz;
     }
 
     public Namespace bindParameters(Interpreter interpreter, BabbleParser.CallContext callSite, Namespace parent, Parameters parameters) {
         Namespace namespace = parent.enter(null);
         try {
-            //noinspection unchecked
-            Constructor<Object> constructor = clazz.getConstructor(parameters.typesArray());
+            Constructor<?> constructor = clazz.getConstructor(parameters.typesArray());
             namespace.define("constructor", true).set(constructor);
             namespace.define("parameters", true).set(parameters);
             return namespace;
@@ -31,8 +30,8 @@ class JavaClass implements Scope<Callable>, Callable<JavaObject> {
         }
     }
 
-    public JavaObject call(Interpreter interpreter, BabbleParser.CallContext callSite, Scope scope) {
-        Constructor constructor = (Constructor) scope.get("constructor").get();
+    public JavaObject call(Interpreter interpreter, BabbleParser.CallContext callSite, Scope<Object> scope) {
+        Constructor<?> constructor = (Constructor<?>) scope.get("constructor").get();
         Parameters parameters = (Parameters) scope.get("parameters").get();
         try {
             return new JavaObject(this, constructor.newInstance(parameters.valuesArray()));
@@ -53,7 +52,7 @@ class JavaClass implements Scope<Callable>, Callable<JavaObject> {
         return members.computeIfAbsent(key, k -> {
             Slot<Callable> result = new Slot<>(k, true);
 
-            for (Class memberClass : clazz.getClasses()) {
+            for (Class<?> memberClass : clazz.getClasses()) {
                 if (memberClass.getSimpleName().equals(k) && Modifier.isPublic(memberClass.getModifiers())) {
                     result.set(new JavaClass(memberClass));
                     break;

--- a/src/main/java/org/babblelang/engine/impl/natives/java/JavaMethod.java
+++ b/src/main/java/org/babblelang/engine/impl/natives/java/JavaMethod.java
@@ -6,11 +6,11 @@ import org.babblelang.parser.BabbleParser;
 
 import java.lang.reflect.Method;
 
-class JavaMethod implements Callable {
-    private final Class clazz;
+class JavaMethod implements Callable<Object> {
+    private final Class<?> clazz;
     private final String name;
 
-    JavaMethod(Class clazz, String name) {
+    JavaMethod(Class<?> clazz, String name) {
         this.clazz = clazz;
         this.name = name;
     }
@@ -19,7 +19,6 @@ class JavaMethod implements Callable {
         Namespace namespace = parent.enter(null);
 
         try {
-            //noinspection unchecked
             Method method = clazz.getMethod(name, parameters.typesArray());
             namespace.define("method", true).set(method);
             namespace.define("parameters", true).set(parameters);
@@ -31,7 +30,7 @@ class JavaMethod implements Callable {
         return namespace;
     }
 
-    public Object call(Interpreter interpreter, BabbleParser.CallContext callSite, Scope scope) {
+    public Object call(Interpreter interpreter, BabbleParser.CallContext callSite, Scope<Object> scope) {
         Method method = (Method) scope.get("method").get();
         Parameters parameters = (Parameters) scope.get("parameters").get();
         try {

--- a/src/main/java/org/babblelang/engine/optimizer/SimpleBinaryOpsOptimizer.java
+++ b/src/main/java/org/babblelang/engine/optimizer/SimpleBinaryOpsOptimizer.java
@@ -16,74 +16,73 @@ public class SimpleBinaryOpsOptimizer extends OptimizerBase {
         ctx.right = (BabbleParser.ExpressionContext) visit(ctx.right);
 
         switch (ctx.op.getType()) {
-            case BabbleLexer.PLUS:
-                if (ctx.left instanceof BabbleParser.IntegerContext && ctx.left.getText().equals("0")) {
+            case BabbleLexer.PLUS -> {
+                if (isIntegerLiteral(ctx.left, "0")) {
                     result = replace(ctx, ctx.right);
-                } else if (ctx.right instanceof BabbleParser.IntegerContext && ctx.right.getText().equals("0")) {
+                } else if (isIntegerLiteral(ctx.right, "0")) {
                     result = replace(ctx, ctx.left);
                 }
-                break;
+            }
 
-            case BabbleLexer.MINUS:
-                if (ctx.right instanceof BabbleParser.IntegerContext && ctx.right.getText().equals("0")) {
+            case BabbleLexer.MINUS -> {
+                if (isIntegerLiteral(ctx.right, "0")) {
                     result = replace(ctx, ctx.left);
                 }
-                break;
+            }
 
-            case BabbleLexer.MUL:
-                if (ctx.left instanceof BabbleParser.IntegerContext) {
-                    if (ctx.left.getText().equals("1")) {
-                        result = replace(ctx, ctx.right);
-                        break;
-                    } else if (ctx.left.getText().equals("0")) {
-                        result = replace(ctx, ctx.left);
-                        break;
-                    }
+            // A left operand that is an integer other than 0 or 1 falls through to the
+            // right-hand checks, so these have to stay a single else-if chain.
+            case BabbleLexer.MUL -> {
+                if (isIntegerLiteral(ctx.left, "1")) {
+                    result = replace(ctx, ctx.right);
+                } else if (isIntegerLiteral(ctx.left, "0")) {
+                    result = replace(ctx, ctx.left);
+                } else if (isIntegerLiteral(ctx.right, "1")) {
+                    result = replace(ctx, ctx.left);
+                } else if (isIntegerLiteral(ctx.right, "0")) {
+                    result = replace(ctx, ctx.right);
                 }
-                if (ctx.right instanceof BabbleParser.IntegerContext) {
-                    if (ctx.right.getText().equals("1")) {
-                        result = replace(ctx, ctx.left);
-                    } else if (ctx.right.getText().equals("0")) {
-                        result = replace(ctx, ctx.right);
-                    }
-                }
-                break;
+            }
 
-            case BabbleLexer.DIV:
-                if (ctx.right instanceof BabbleParser.IntegerContext && ctx.right.getText().equals("1")) {
+            case BabbleLexer.DIV -> {
+                if (isIntegerLiteral(ctx.right, "1")) {
                     result = replace(ctx, ctx.left);
                 }
-                break;
+            }
+
+            default -> {
+                // not a simplifiable operator
+            }
         }
         return result;
+    }
+
+    private static boolean isIntegerLiteral(BabbleParser.ExpressionContext ctx, String text) {
+        return ctx instanceof BabbleParser.IntegerContext && ctx.getText().equals(text);
     }
 
     @Override
     public RuleNode visitBlockExpression(BabbleParser.BlockExpressionContext ctx) {
         RuleNode result = super.visitBlockExpression(ctx);
-        if (!(result instanceof BabbleParser.BlockExpressionContext)) {
+        if (!(result instanceof BabbleParser.BlockExpressionContext block)) {
             return result;
         }
-        ctx = (BabbleParser.BlockExpressionContext) result;
-        if (ctx.block().expression().size() == 1) {
-            return replace(ctx, ctx.block().expression(0));
+        if (block.block().expression().size() == 1) {
+            return replace(block, block.block().expression(0));
         }
-        return ctx;
+        return block;
     }
 
     @Override
     public RuleNode visitBooleanNot(BabbleParser.BooleanNotContext ctx) {
         RuleNode result = super.visitBooleanNot(ctx);
-        if (!(result instanceof BabbleParser.BooleanNotContext)) {
+        if (!(result instanceof BabbleParser.BooleanNotContext not)) {
             return result;
         }
-        ctx = (BabbleParser.BooleanNotContext) result;
-        BabbleParser.ExpressionContext child =
-                ctx.expression();
-        if (child instanceof BabbleParser.BooleanNotContext) {
-            return replace(ctx, ((BabbleParser.BooleanNotContext) ctx.expression()).expression());
+        if (not.expression() instanceof BabbleParser.BooleanNotContext inner) {
+            return replace(not, inner.expression());
         }
         // TODO: replace "not false" with "true", and "not true" with "false".
-        return ctx;
+        return not;
     }
 }


### PR DESCRIPTION
Follow-up to the Java 21 / JUnit 5 toolchain migration (#3). That PR left the 24 main-source files on Java 8 idioms; this one brings them up to Java 21. **No behavioural change** — the language and interpreter semantics are unchanged and the test suite is untouched. Build is warning-clean under `-Xlint`, all 61 tests pass.

## The substantive part: raw types

`Function`, `BoundMethod`, `PrintFunction`, `JavaMethod`, `BoundJavaMethod`, `JavaClass`, and `ImportFunction` all declared a **raw `Scope`** parameter while the `Callable` interface declares `Scope<Object>` — so they were satisfying the interface only by erasure. These are now `Scope<Object>`, and the reflection classes use `Class<?>` instead of raw `Class`. Between them this removed two `//noinspection unchecked` suppressions.

The one genuinely uncheckable cast — `(R)` in `Function.call`, inherent because the interpreter is untyped — is now an explicit `@SuppressWarnings("unchecked")` with a note, rather than an unmarked warning.

## Idiom updates

- Pattern-matching `instanceof` in `truth()`, `number()`, `visitCall()`, `BabbleObject.get()`, and both optimizer visitors
- Arrow switches
- `String.join` replacing two hand-rolled `StringBuilder` loops in the factory
- `List.of`, and `values().toArray()` replacing a manual copy loop in `Parameters`

## Two deliberate non-changes worth reviewing

1. **`visitBinaryOp` uses an arrow switch with `return`, not a switch *expression* with `yield`.** A switch expression would apply binary numeric promotion across its arms, silently turning `12 * 12` from `Integer 144` into `Double 144.0` — a semantic change to the language. `return` boxes each arm independently. Test-covered (`BabbleExpressionsTestCase` asserts `144` and `6.0` distinctly), but the shape is intentional.
2. **`Slot` stays a class, not a record** — it's mutable (`set`/`value`), so `record` doesn't apply. (Correcting my own earlier suggestion that it was a record candidate.)

## Optimizer fallthrough

The `MUL` case relied on non-obvious fallthrough — an integer left operand that is neither `0` nor `1` continues to the right-hand checks. Preserved as an else-if chain and commented; the repeated `instanceof IntegerContext && getText().equals(...)` test is extracted into `isIntegerLiteral()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)